### PR TITLE
Restores attract mode title/hi score loop.

### DIFF
--- a/arduboy-game/arduboy-game.ino
+++ b/arduboy-game/arduboy-game.ino
@@ -157,7 +157,7 @@ void introScreen() {
 
 byte titleScreen() {
   byte selectedItem = TITLE_PLAY_GAME;
-  unsigned short totalDelay = 0;
+  unsigned long totalDelay = 0;
   long lastDebounceTime = millis();  // the last time the button was pressed
   
   arduboy.clear();
@@ -203,8 +203,6 @@ byte titleScreen() {
       }
     }
   
-
-//    delay(40);
     totalDelay ++;
 
   }


### PR DESCRIPTION
Returns behavior where title screen cuts to hi score screen periodically if the user doesn't select an option from the title screen.