### PR TITLE
Refactor/top 3 hi scores

### DIFF
--- a/arduboy-game/arduboy-game.ino
+++ b/arduboy-game/arduboy-game.ino
@@ -102,7 +102,6 @@ char textBuf[23];
 
 
 void playMusic(byte song) {
-  return;
     if (! soundOn) {
       return;
     }


### PR DESCRIPTION
Limits hi scores to top 3, changes their implementation to fix a bug that was in develop for ages (new highest score would corrupt initials of the former highest score when pushing it down to second in the table).