### PR TITLE
Replaces score based boss spawning with kill based method h/t Tim Eagan.

### DIFF
--- a/arduboy-game/arduboy-game.ino
+++ b/arduboy-game/arduboy-game.ino
@@ -56,6 +56,7 @@ char highScoreTable[27] = "AAA000300BBB000200CCC000100";
 
 unsigned long inGameAButtonLastPress, inGameBButtonLastPress, inGameLastDeath, score;
 byte livesRemaining = MAX_LIVES;
+byte currentKills = 0;
 
 float starX[NUM_STARS];
 float starSpeed[NUM_STARS];
@@ -569,7 +570,7 @@ void playGame() {
 
     // This logic seems way too nested and can probably be simplified a little. :) -- JG
     if (!isBossAlive) {
-      if ((score >= BOSS1_SCORE + (currentIteration * BOSS3_SCORE)) && (spawnedBoss < 1)) {        
+      if ((currentKills >= BOSS1_MIN_KILLS) && (spawnedBoss < 1)) {        
         if (isBossAlive = stopSpawningEnemies = !enemiesAlive) {
           boss.set(129, 28, 128, currentIteration);
           spawnedBoss = 1;
@@ -578,7 +579,7 @@ void playGame() {
 //        else {
 //          stopSpawningEnemies = true;
 //        }
-      } else if ((score >= (BOSS2_SCORE + (currentIteration * BOSS3_SCORE))) && (spawnedBoss < 2)) {
+      } else if ((currentKills >= (BOSS1_MIN_KILLS + BOSS2_MIN_KILLS)) && (spawnedBoss < 2)) {
         if (isBossAlive = stopSpawningEnemies = !enemiesAlive) {
           boss.set(129, 24, 129, currentIteration);
           spawnedBoss = 2;
@@ -587,7 +588,7 @@ void playGame() {
 //        else {
 //          stopSpawningEnemies = true;
 //        }
-      } else if ((score >= (BOSS3_SCORE + (currentIteration * BOSS3_SCORE))) && (spawnedBoss < 3)) {
+      } else if ((currentKills >= (BOSS1_MIN_KILLS + BOSS2_MIN_KILLS + BOSS3_MIN_KILLS)) && (spawnedBoss < 3)) {
         if (isBossAlive = stopSpawningEnemies =!enemiesAlive) {
           boss.set(129, 10, 130, currentIteration);
           spawnedBoss = 3;
@@ -642,6 +643,7 @@ void playGame() {
 
       // Set them on the next iteration
       currentIteration = (currentIteration == 254 ? 0 : currentIteration + 1);
+      currentKills = 0;
     }
     
     handleEnemyBullets();
@@ -857,6 +859,7 @@ boolean handlePlayerBullets() {
             if (playerBullets[i].damage > enemies[j].health) {
               enemies[j].health = 0;
               enemies[j].dying = 1;
+              currentKills++;
               score += 100;
             } else {
               enemies[j].health -= playerBullets[i].damage;

--- a/arduboy-game/globals.h
+++ b/arduboy-game/globals.h
@@ -16,9 +16,9 @@
 #define MIN_ENEMY_SHIP_X 92
 #define MAX_ENEMY_SHIP_X 112
 
-#define BOSS1_SCORE 5000ul
-#define BOSS2_SCORE 12000ul
-#define BOSS3_SCORE 20000ul
+#define BOSS1_MIN_KILLS 20
+#define BOSS2_MIN_KILLS 25
+#define BOSS3_MIN_KILLS 30
 
 // Time before title screen flips to high score screen
 #define ATTRACT_MODE_TIMEOUT 400000


### PR DESCRIPTION
Replaces boss spawning by score which varied per wave with boss spawning after a number of kills.

Test this by removing 

```
livesRemaining--;
``

from the main sketch file to become invincible.

Thanks @sulfurious for the idea.